### PR TITLE
通过GithubAction 自动创建发行版

### DIFF
--- a/.github/workflows/Auto Create Release.yml
+++ b/.github/workflows/Auto Create Release.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           files: ''
           tag_name: ${{ steps.get_version.outputs.version }}
-          #title: Release ${{ steps.get_version.outputs.version }}
+          #body_path: # 更新内容可以放这里

--- a/.github/workflows/Auto Create Release.yml
+++ b/.github/workflows/Auto Create Release.yml
@@ -1,0 +1,35 @@
+name: Create Release on Version Update
+
+on:
+  push:
+    paths:
+      - 'app/build.gradle'
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt' 
+
+      - name: Get versionName from build.gradle
+        id: get_version
+        run: |
+          version=$(grep 'versionName' app/build.gradle | sed -n 's/.*"\(.*\)"/\1/p')
+          echo "::set-output name=version::v$version"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        with:
+          files: ''
+          tag_name: ${{ steps.get_version.outputs.version }}
+          #title: Release ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
通过测试，此方法可以自动创建发行版、并触发自动编译APK

触发条件：更新 'app/build.gradle'文件中的版本号

效果： 如'app/build.gradle'文件中版本号为1.1.1，则会生成一个v1.1.1的空标签，并触发自动编译。