### PR TITLE
更新workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,23 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Sign app APK
-        uses: ilharp/sign-android-release@v1
+        uses: noriban/sign-android-release@v3
         id: sign_app
         with:
-          releaseDir: app/build/outputs/apk/release/
-          signingKey: ${{ secrets.ANDROID_SIGNING_KEY }}
-          keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          releaseDirectory: app/build/outputs/apk/release/
+          signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}
+          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          buildToolsVersion: 30.0.3
+        env:
+          BUILD_TOOLS_VERSION: "30.0.3"
 
       - name: Upload to Release Action
-        uses: Shopify/upload-to-release@v1.0.1
+        uses: termux/upload-release-action@v4.1.0
         with:
-          name: xqe-sesame-${{ github.event.release.tag_name }}.apk
-          path: ${{ steps.sign_app.outputs.signedFile }}
-          repo-token: ${{ github.token }}
-          content-type: application/zip
+          asset_name: xqe-sesame-${{ github.event.release.tag_name }}.apk
+          file: ${{ steps.sign_app.outputs.signedFile }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          checksums: sha256

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         minSdk 21
         //noinspection ExpiredTargetSdkVersion
         targetSdk 29
-        versionCode 70
-        versionName "1.2.2-fix1"
+        versionCode 71
+        versionName "1.2.2-fix2"
     }
     buildTypes {
         release {

--- a/app/src/main/java/pansong291/xposed/quickenergy/AntForest.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/AntForest.java
@@ -439,6 +439,28 @@ public class AntForest {
                                 } else {
                                     Log.recordLog("收取[我]的复活金球失败:" + joEnergy.getString("resultDesc"), str);
                                 }
+                            } else if ("baohuhuizeng".equals(bizType)) {
+                                String friendId = wateringBubble.getString("userId");
+                                String str = AntForestRpcCall.collectEnergy(bizType, selfId,
+                                        wateringBubble.getLong("id"));
+                                JSONObject joEnergy = new JSONObject(str);
+                                if ("SUCCESS".equals(joEnergy.getString("resultCode"))) {
+                                    JSONArray bubbles = joEnergy.getJSONArray("bubbles");
+                                    for (int j = 0; j < bubbles.length(); j++) {
+                                        collected = bubbles.getJSONObject(j).getInt("collectedEnergy");
+                                    }
+                                    if (collected > 0) {
+                                        totalCollected += collected;
+                                        Statistics.addData(Statistics.DataType.COLLECTED, collected);
+                                        String msg = "收取金球🍯[" + FriendIdMap.getNameById(friendId) + "]复活回赠[" + collected + "g]";
+                                        Log.forest(msg);
+                                        AntForestToast.show(msg);
+                                    } else {
+                                        Log.recordLog("收取[" + FriendIdMap.getNameById(friendId) + "]的复活回赠金球失败", "");
+                                    }
+                                } else {
+                                    Log.recordLog("收取[" + FriendIdMap.getNameById(friendId) + "]的复活回赠金球失败:" + joEnergy.getString("resultDesc"), str);
+                                }
                             }
                             Thread.sleep(1000L);
                         }


### PR DESCRIPTION
使用`noriban/sign-android-release@v3`替代`ilharp/sign-android-release@v1`进行app签名;
使用`termux/upload-release-action@v4.1.0`替代`Shopify/upload-to-release@v1.0.1`进行文件上传至release;

原因：之前的action当前缺乏维护，可能与当前github action默认使用的nodejs版本不兼容。