### PR TITLE
github action 使用 termux/upload-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,11 @@ jobs:
           buildToolsVersion: 30.0.3
 
       - name: Upload to Release Action
-        uses: Shopify/upload-to-release@v1.0.1
+        uses: termux/upload-release-action@v4.1.0
         with:
-          name: xqe-sesame-${{ github.event.release.tag_name }}.apk
-          path: ${{ steps.sign_app.outputs.signedFile }}
-          repo-token: ${{ github.token }}
-          content-type: application/zip
+          asset_name: xqe-sesame-${{ github.event.release.tag_name }}.apk
+          file: ${{ steps.sign_app.outputs.signedFile }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          checksums: sha256


### PR DESCRIPTION
因github action 不再支持node12，而`Shopify/upload-to-release`目前尚未更新，所以改用`termux/upload-release-action`上传文件至release