### PR TITLE
增加始终中文语言选项，新版10.5.53不工作问题修复

### DIFF
--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/HtmlViewerActivity.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/HtmlViewerActivity.java
@@ -14,6 +14,7 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 import pansong291.xposed.quickenergy.R;
+import pansong291.xposed.quickenergy.util.LanguageUtil;
 
 public class HtmlViewerActivity extends Activity {
     MyWebView mWebView;
@@ -22,6 +23,7 @@ public class HtmlViewerActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        LanguageUtil.setLocale(this);
         setContentView(R.layout.activity_html_viewer);
 
         mWebView = findViewById(R.id.mwv_webview);

--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/MainActivity.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/MainActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
@@ -17,15 +18,18 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import pansong291.xposed.quickenergy.R;
 import pansong291.xposed.quickenergy.data.RuntimeInfo;
 import pansong291.xposed.quickenergy.entity.FriendWatch;
 import pansong291.xposed.quickenergy.util.Config;
 import pansong291.xposed.quickenergy.util.FileUtils;
+import pansong291.xposed.quickenergy.util.LanguageUtil;
 import pansong291.xposed.quickenergy.util.PermissionUtil;
 import pansong291.xposed.quickenergy.util.Statistics;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class MainActivity extends Activity {
     TextView tvStatistics;
@@ -63,6 +67,7 @@ public class MainActivity extends Activity {
         }
         return isExp;
     }
+
     /**
      * 判断当前应用是否是debug状态
      */
@@ -78,6 +83,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        LanguageUtil.setLocale(this);
         setContentView(R.layout.activity_main);
         RuntimeInfo.process = "app";
 

--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/SettingsActivity.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/SettingsActivity.java
@@ -2,6 +2,7 @@ package pansong291.xposed.quickenergy.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -12,6 +13,9 @@ import android.widget.Button;
 import android.widget.Switch;
 import android.widget.TabHost;
 import android.widget.Toast;
+
+import java.util.Locale;
+
 import pansong291.xposed.quickenergy.R;
 import pansong291.xposed.quickenergy.entity.*;
 import pansong291.xposed.quickenergy.util.*;
@@ -30,7 +34,7 @@ public class SettingsActivity extends Activity {
     private Animation slideRightIn;
     private Animation slideRightOut;
 
-    Switch sw_immediateEffect, sw_recordLog, sw_showToast, sw_stayAwake, sw_timeoutRestart, sw_startAt7,
+    Switch sw_immediateEffect, sw_recordLog, sw_showToast, sw_stayAwake, sw_timeoutRestart, sw_startAt7, sw_language_simplified_chinese,
             sw_collectWateringBubble, sw_collectProp, sw_collectEnergy, sw_helpFriendCollect, sw_receiveForestTaskAward,
             sw_cooperateWater, sw_energyRain, sw_enableFarm, sw_rewardFriend, sw_sendBackAnimal,
             sw_receiveFarmToolReward, sw_useNewEggTool, sw_harvestProduce, sw_donation, sw_answerQuestion,
@@ -47,6 +51,7 @@ public class SettingsActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        LanguageUtil.setLocale(this);
         setContentView(R.layout.activity_settings);
         setTitle(R.string.settings);
 
@@ -61,7 +66,9 @@ public class SettingsActivity extends Activity {
         BeachIdMap.shouldReload = true;
 
         initSwitch();
+
     }
+
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent event) {
@@ -98,7 +105,7 @@ public class SettingsActivity extends Activity {
         gestureDetector = new GestureDetector(this, new GestureDetector.SimpleOnGestureListener() {
             @Override
             public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX,
-                    float velocityY) {
+                                   float velocityY) {
                 if (Math.abs(e1.getY() - e2.getY()) > SWIPE_MAX_OFF_PATH)
                     return false;
                 int lastView = tabHost.getCurrentTab();
@@ -159,6 +166,7 @@ public class SettingsActivity extends Activity {
         sw_startAt7 = findViewById(R.id.sw_startAt7);
         sw_enableOnGoing = findViewById(R.id.sw_enableOnGoing);
         sw_backupRuntime = findViewById(R.id.sw_backupRuntime);
+        sw_language_simplified_chinese = findViewById(R.id.sw_languageSimplifiedChinese);
 
         sw_collectEnergy = findViewById(R.id.sw_collectEnergy);
         sw_collectWateringBubble = findViewById(R.id.sw_collectWateringBubble);
@@ -233,6 +241,7 @@ public class SettingsActivity extends Activity {
         sw_startAt7.setChecked(Config.startAt7());
         sw_enableOnGoing.setChecked(Config.enableOnGoing());
         sw_backupRuntime.setChecked(Config.backupRuntime());
+        sw_language_simplified_chinese.setChecked(Config.languageSimplifiedChinese());
 
         sw_collectEnergy.setChecked(Config.collectEnergy());
         sw_collectWateringBubble.setChecked(Config.collectWateringBubble());
@@ -331,6 +340,12 @@ public class SettingsActivity extends Activity {
 
                 case R.id.sw_backupRuntime:
                     Config.setBackupRuntime(sw.isChecked());
+                    break;
+
+                case R.id.sw_languageSimplifiedChinese:
+                    Config.setLanguageSimplifiedChinese(sw.isChecked());
+                    // 提示需要重启 language_simplified_chinese_need_restart
+                    Toast.makeText(this, R.string.language_simplified_chinese_need_restart, Toast.LENGTH_SHORT).show();
                     break;
 
                 case R.id.sw_collectEnergy:

--- a/app/src/main/java/pansong291/xposed/quickenergy/util/Config.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/util/Config.java
@@ -43,6 +43,7 @@ public class Config {
     public static final String jn_startAt7 = "startAt7";
     public static final String jn_enableOnGoing = "enableOnGoing";
     public static final String jn_backupRuntime = "backupRuntime";
+    public static final String jn_languageSimplifiedChinese = "languageSimplifiedChinese";
 
     /* forest */
     public static final String jn_collectEnergy = "collectEnergy";
@@ -163,6 +164,8 @@ public class Config {
     private boolean startAt7;
     private boolean enableOnGoing;
     private boolean backupRuntime;
+    private boolean languageSimplifiedChinese;
+
 
     /* forest */
     private boolean collectEnergy;
@@ -395,8 +398,17 @@ public class Config {
         hasChanged = true;
     }
 
+    public static void setLanguageSimplifiedChinese(boolean b) {
+        getConfig().languageSimplifiedChinese = b;
+        hasChanged = true;
+    }
+
     public static boolean backupRuntime() {
         return getConfig().backupRuntime;
+    }
+
+    public static boolean languageSimplifiedChinese() {
+        return getConfig().languageSimplifiedChinese;
     }
 
     /* forest */
@@ -1324,6 +1336,7 @@ public class Config {
         c.startAt7 = false;
         c.enableOnGoing = false;
         c.backupRuntime = false;
+        c.languageSimplifiedChinese = false;
 
         c.collectEnergy = false;
         c.collectWateringBubble = true;
@@ -1506,6 +1519,9 @@ public class Config {
 
             config.backupRuntime = jo.optBoolean(jn_backupRuntime, false);
             //Log.i(TAG, jn_backupRuntime + ":" + config.backupRuntime);
+
+            config.languageSimplifiedChinese = jo.optBoolean(jn_languageSimplifiedChinese, false);
+            //Log.i(TAG, jn_languageSimplifiedChinese + ":" + config.languageSimplifiedChinese);
 
             /* forest */
             config.collectEnergy = jo.optBoolean(jn_collectEnergy, false);
@@ -1997,6 +2013,8 @@ public class Config {
             jo.put(jn_enableOnGoing, config.enableOnGoing);
 
             jo.put(jn_backupRuntime, config.backupRuntime);
+
+            jo.put(jn_languageSimplifiedChinese, config.languageSimplifiedChinese);
 
             /* forest */
             jo.put(jn_collectEnergy, config.collectEnergy);

--- a/app/src/main/java/pansong291/xposed/quickenergy/util/FileUtils.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/util/FileUtils.java
@@ -3,6 +3,7 @@ package pansong291.xposed.quickenergy.util;
 import android.os.Environment;
 import pansong291.xposed.quickenergy.AntForestToast;
 import pansong291.xposed.quickenergy.data.RuntimeInfo;
+import pansong291.xposed.quickenergy.hook.ClassMember;
 
 import java.io.Closeable;
 import java.io.File;
@@ -49,7 +50,8 @@ public class FileUtils {
     @SuppressWarnings("deprecation")
     public static File getMainDirectoryFile() {
         if (mainDirectory == null) {
-            File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            String storageDirStr = Environment.getExternalStorageDirectory() + File.separator + "Android" + File.separator + "media" + File.separator + ClassMember.PACKAGE_NAME;
+            File storageDir = new File(storageDirStr);
             if (!storageDir.exists()) {
                 storageDir.mkdirs();
             }

--- a/app/src/main/java/pansong291/xposed/quickenergy/util/LanguageUtil.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/util/LanguageUtil.java
@@ -1,0 +1,21 @@
+package pansong291.xposed.quickenergy.util;
+
+import android.content.res.Configuration;
+
+import java.util.Locale;
+
+import android.content.Context;
+
+
+public class LanguageUtil {
+    public static void setLocale(Context context) {
+        if (Config.languageSimplifiedChinese()) {
+            // 忽略系统语言，强制使用简体中文
+            Locale locale = new Locale("zh", "CN"); // 简体中文的区域代码
+            Locale.setDefault(locale);
+            Configuration config = new Configuration();
+            config.locale = locale;
+            context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -175,6 +175,16 @@
 						android:onClick="onClick"
 						android:minHeight="50dp"
 						android:id="@+id/sw_backupRuntime" />
+
+					<Switch
+						android:paddingStart="@dimen/setting_item_padding"
+						android:paddingEnd="@dimen/setting_item_padding"
+						android:layout_width="match_parent"
+						android:layout_height="wrap_content"
+						android:text="@string/language_simplified_chinese"
+						android:onClick="onClick"
+						android:minHeight="50dp"
+						android:id="@+id/sw_languageSimplifiedChinese" />
 				</LinearLayout>
 				<!--森林设置-->
 				<LinearLayout

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -118,6 +118,8 @@
     <string name="ins_blue_bean_exchange">安心豆兑换时光加速器</string>
     <string name="enable_on_going">开启状态栏禁删</string>
     <string name="backup_runtime_log">备份runtime日志</string>
+    <string name="language_simplified_chinese">界面始终使用中文</string>
+    <string name="language_simplified_chinese_need_restart">重启当前app生效</string>
     <string name="ant_orchard">施肥</string>
     <string name="receive_orchard_task_award">收取施肥任务奖励</string>
     <string name="orchard_spread_manure_count">施肥次数</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,8 @@
     <string name="ins_blue_bean_exchange">Ins blue bean exchange</string>
     <string name="enable_on_going">Enable on going</string>
     <string name="backup_runtime_log">Backup runtime log</string>
+    <string name="language_simplified_chinese">Chinese Language</string>
+    <string name="language_simplified_chinese_need_restart">Need to restart the app to take effect</string>
     <string name="ant_orchard">Ant orchard</string>
     <string name="receive_orchard_task_award">Receive orchard task award</string>
     <string name="orchard_spread_manure_count">Orchard spread manure count</string>


### PR DESCRIPTION
应用跟随系统语言，英文语言系统情况下部分文字长度表达不够直观展示，增加一个始终中文选项独立于系统语言。
- [x] 模拟器API34测试通过
- [x] 小米Fold3测试通过