### PR TITLE
增加“多选”和“反选”

### DIFF
--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/ListAdapter.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/ListAdapter.java
@@ -23,6 +23,8 @@ public class ListAdapter extends BaseAdapter {
     public static ListAdapter get(Context c) {
         if (adapter == null)
             adapter = new ListAdapter(c);
+        adapter.findIndex = -1;
+        adapter.findWord = null;
         return adapter;
     }
 
@@ -32,6 +34,8 @@ public class ListAdapter extends BaseAdapter {
             viewHolderList = new ArrayList<>();
         }
         ListAdapter.listType = listType;
+        adapter.findIndex = -1;
+        adapter.findWord = null;
         return adapter;
     }
 

--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/ListAdapter.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/ListAdapter.java
@@ -66,8 +66,7 @@ public class ListAdapter extends BaseAdapter {
         }
     }
 
-    public int
-    findLast(CharSequence cs) {
+    public int findLast(CharSequence cs) {
         if (list == null || list.isEmpty())
             return -1;
         if (!cs.equals(findWord)) {
@@ -114,6 +113,26 @@ public class ListAdapter extends BaseAdapter {
 
     public void exitFind() {
         findIndex = -1;
+    }
+
+    public void selectAll(){
+        selects.clear();
+        for(IdAndName ai:list){
+            selects.add(ai.id);
+        }
+        notifyDataSetChanged();
+    }
+
+    public void SelectInvert(){
+        List<String> newSelects = new ArrayList<>();
+        for(IdAndName ai:list){
+            if(!selects.contains(ai.id)){
+                newSelects.add(ai.id);
+            }
+        }
+        selects.clear();
+        selects.addAll(newSelects);
+        notifyDataSetChanged();
     }
 
     @Override

--- a/app/src/main/java/pansong291/xposed/quickenergy/ui/ListDialog.java
+++ b/app/src/main/java/pansong291/xposed/quickenergy/ui/ListDialog.java
@@ -14,6 +14,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.Toast;
+import android.widget.RelativeLayout;
 import java.util.List;
 import pansong291.xposed.quickenergy.R;
 import pansong291.xposed.quickenergy.entity.AlipayUser;
@@ -26,7 +27,8 @@ import pansong291.xposed.quickenergy.util.FriendIdMap;
 
 public class ListDialog {
     static AlertDialog listDialog;
-    static Button btn_find_last, btn_find_next;
+    static Button btn_find_last, btn_find_next,
+            btn_select_all, btn_select_invert;
     static EditText edt_find;
     static ListView lv_list;
     static List<String> selectedList;
@@ -41,6 +43,8 @@ public class ListDialog {
 
     static AlertDialog optionsDialog;
     static AlertDialog deleteDialog;
+
+    static RelativeLayout layout_batch_process;
 
     public enum ListType {
         RADIO, CHECK, SHOW
@@ -77,7 +81,7 @@ public class ListDialog {
             listDialog = new AlertDialog.Builder(c)
                     .setTitle("title")
                     .setView(getListView(c))
-                    .setPositiveButton(c.getString(R.string.ok), null)
+                    .setPositiveButton(c.getString(R.string.close), null)
                     .create();
         listDialog.setOnShowListener(
                 new OnShowListener() {
@@ -90,6 +94,9 @@ public class ListDialog {
 
                     @Override
                     public void onShow(DialogInterface p1) {
+                        AlertDialog d = (AlertDialog) p1;
+                        layout_batch_process = d.findViewById(R.id.layout_batch_process);
+                        layout_batch_process.setVisibility(listType==ListType.CHECK&&countList==null?View.VISIBLE:View.GONE);
                         ListAdapter.get(c).notifyDataSetChanged();
                     }
                 }.setContext(c));
@@ -98,11 +105,19 @@ public class ListDialog {
 
     private static View getListView(Context c) {
         View v = LayoutInflater.from(c).inflate(R.layout.dialog_list, null);
-        OnBtnClickListener onBtnClickListener = new OnBtnClickListener();
+
         btn_find_last = v.findViewById(R.id.btn_find_last);
         btn_find_next = v.findViewById(R.id.btn_find_next);
+        btn_select_all = v.findViewById(R.id.btn_select_all);
+        btn_select_invert = v.findViewById(R.id.btn_select_invert);
+
+        OnBtnClickListener onBtnClickListener = new OnBtnClickListener();
+        BatchBtnOnClickListener batchBtnOnClickListener = new BatchBtnOnClickListener();
         btn_find_last.setOnClickListener(onBtnClickListener);
         btn_find_next.setOnClickListener(onBtnClickListener);
+        btn_select_all.setOnClickListener(batchBtnOnClickListener);
+        btn_select_invert.setOnClickListener(batchBtnOnClickListener);
+
         edt_find = v.findViewById(R.id.edt_find);
         lv_list = v.findViewById(R.id.lv_list);
         lv_list.setAdapter(ListAdapter.get(c));
@@ -348,6 +363,23 @@ public class ListDialog {
             } else {
                 lv_list.setSelection(index);
             }
+        }
+    }
+
+    static class BatchBtnOnClickListener implements View.OnClickListener {
+        @SuppressLint("NonConstantResourceId")
+        @Override
+        public void onClick(View p1) {
+            ListAdapter la = ListAdapter.get(p1.getContext());
+            switch (p1.getId()) {
+                case R.id.btn_select_all:
+                    la.selectAll();
+                    break;
+                case R.id.btn_select_invert:
+                    la.SelectInvert();
+                    break;
+            }
+            Config.hasChanged = true;
         }
     }
 

--- a/app/src/main/res/layout/dialog_list.xml
+++ b/app/src/main/res/layout/dialog_list.xml
@@ -5,6 +5,38 @@
 	android:layout_height="match_parent"
 	android:orientation="vertical">
 
+	<RelativeLayout
+		android:id="@+id/layout_batch_process"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:visibility="visible">
+
+		<Button
+			android:id="@+id/btn_select_invert"
+			style="?android:attr/buttonBarButtonStyle"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_alignParentRight="true"
+			android:background="@drawable/button"
+			android:minHeight="50dp"
+			android:padding="12dp"
+			android:text="@string/select_invert"
+			android:textAllCaps="false" />
+
+		<Button
+			android:id="@+id/btn_select_all"
+			style="?android:attr/buttonBarButtonStyle"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_toLeftOf="@+id/btn_select_invert"
+			android:background="@drawable/button"
+			android:minHeight="50dp"
+			android:padding="12dp"
+			android:text="@string/select_all"
+			android:textAllCaps="false" />
+
+	</RelativeLayout>
+
 	<ListView
 		android:layout_width="match_parent"
 		android:layout_height="0dp"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -151,5 +151,8 @@
     <string name="total_cert_count">记录证书总数</string>
     <string name="send_friend_card">送好友卡片(赠送当前图鉴所有卡片)</string>
     <string name="batch_rob_energy">一键收能量</string>
+    <string name="select_all">全选</string>
+    <string name="select_invert">反选</string>
+    <string name="close">关闭</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,5 +155,8 @@
     <string name="total_cert_count">Total cert count</string>
     <string name="send_friend_card">Send friend card</string>
     <string name="batch_rob_energy">Batch rob energy</string>
+    <string name="select_all">Select All</string>
+    <string name="select_invert">Select Invert</string>
+    <string name="close">Close</string>
 
 </resources>


### PR DESCRIPTION
1. 对多选框增加”多选“和”反选“功能（在需要设置值的多选框中不增加，如”好友浇水列表“）
<img src="https://github.com/constanline/XQuickEnergy/assets/19186382/a0ec3d68-f1ea-4600-986d-cd5bdf4eb329" width="45%" /><img src="https://github.com/constanline/XQuickEnergy/assets/19186382/712db9f4-a55c-4fa6-9f3b-99a1c18def04" width="45%"/>
2. 重新打开dialog时重设置检索信息（之前重新打开dialog时，之前的检索索引还在，出现文字标红的情况，但是该索引所对应的好友信息并不一定是之前检索的）
