### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
+      - name: set up Android
+        run: |
+          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager \
+          --sdk_root=${ANDROID_SDK_ROOT} \
+          --install  "platforms;android-29" "build-tools;30.0.2"
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -36,7 +42,7 @@ jobs:
           keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          buildToolsVersion: 30.0.3
+          buildToolsVersion: 30.0.2
 
       - name: Upload to Release Action
         uses: termux/upload-release-action@v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,11 @@ jobs:
           buildToolsVersion: 30.0.3
 
       - name: Upload to Release Action
-        uses: Shopify/upload-to-release@v1.0.1
+        uses: termux/upload-release-action@v4.1.0
         with:
-          name: xqe-sesame-${{ github.event.release.tag_name }}.apk
-          path: ${{ steps.sign_app.outputs.signedFile }}
-          repo-token: ${{ github.token }}
-          content-type: application/zip
+          asset_name: xqe-sesame-${{ github.event.release.tag_name }}.apk
+          file: ${{ steps.sign_app.outputs.signedFile }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: true
+          checksums: sha256


### PR DESCRIPTION
1. 使用`termux/upload-release-action`替代`Shopify/upload-to-release@v1.0.1`
2. 因新的`ubuntu-latest`不再包含版本31以下的Android SDK，所以需要自行下载